### PR TITLE
feat: don't cache error response

### DIFF
--- a/serve.ts
+++ b/serve.ts
@@ -8,12 +8,14 @@ import { serveFile } from "https://deno.land/std@0.152.0/http/file_server.ts";
 import { serveDirWithTs } from "https://deno.land/x/ts_serve@v1.3.0/mod.ts";
 
 import type { Routing } from "./types.ts";
-import { populationApi, prefecturesApi } from "./server/api.ts";
+import { init, populationApi, prefecturesApi } from "./server/api.ts";
 
 const routing: Routing[] = [prefecturesApi, populationApi];
 const response404 = new Response(STATUS_TEXT[Status.NotFound], {
   status: Status.NotFound,
 });
+
+init();
 
 serve(async (request) => {
   // index.htmlのレスポンス

--- a/server/api.ts
+++ b/server/api.ts
@@ -75,6 +75,7 @@ function getPopulation(prefCode: string): Promise<Population> {
 }
 
 /** 初回実行時に強制的にAPIを呼び出し、キャッシュする */
-export function init() {
-  getPrefectures().catch(console.error);
+export async function init() {
+  prefecturesCache = undefined;
+  await getPrefectures().catch(console.error);
 }

--- a/server/api.ts
+++ b/server/api.ts
@@ -6,25 +6,11 @@ const PREFECTURES_URL =
 const POPULATION_URL =
   "https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?cityCode=-&prefCode=";
 
-// 都道府県APIのレスポンスをキャッシュする
-// NOTE: avoid Top-Level-Await!!!
-const prefectures: Promise<Prefectures> = (async () => {
-  const res = await fetch(PREFECTURES_URL, {
-    headers: {
-      "X-API-KEY": RESAS_API_KEY,
-    },
-  });
-  return (await res.json()).result;
-})();
-
-// 人口APIのレスポンスをキャッシュする
-const populationCache: Record<string, Promise<Population>> = {};
-
 /** 都道府県APIの設定 */
 export const prefecturesApi = {
   pattern: new URLPattern({ pathname: "/api/prefectures" }),
   async route(): Promise<Response | undefined> {
-    return Response.json(await prefectures);
+    return Response.json(await getPrefectures());
   },
 };
 
@@ -35,18 +21,55 @@ export const populationApi = {
     _url: URL,
     { pathname: { groups: { prefCode } } }: URLPatternResult,
   ): Promise<Response | undefined> {
-    populationCache[prefCode] ??= getPopulation(prefCode);
-    return Response.json(await populationCache[prefCode]);
+    return Response.json(await getPopulation(prefCode));
   },
 };
 
+// 人口APIのレスポンスをキャッシュする
+const populationCache: Record<string, Promise<Population> | undefined> = {};
 /** 人口APIを呼び出す */
-async function getPopulation(prefCode: string) {
-  const res = await fetch(`${POPULATION_URL}${prefCode}`, {
-    headers: {
-      "X-API-KEY": RESAS_API_KEY,
-    },
-  });
-  return (await res.json()).result.data
-    .find((v: Record<string, string>) => v.label === "総人口").data;
+function getPopulation(prefCode: string): Promise<Population> {
+  if (populationCache[prefCode]) {
+    return populationCache[prefCode]!;
+  }
+
+  return populationCache[prefCode] = (async () => {
+    const res = await fetch(`${POPULATION_URL}${prefCode}`, {
+      headers: { "X-API-KEY": RESAS_API_KEY },
+    });
+
+    // エラー時はキャッシュしない
+    if (!res.ok) {
+      console.error("failed to fetch API", res);
+      throw new Error("failed to fetch API");
+    }
+
+    return (await res.json()).result.data
+      .find((v: Record<string, string>) => v.label === "総人口").data;
+  })();
 }
+
+// 都道府県APIのレスポンスをキャッシュする
+let prefecturesCache: Promise<Prefectures> | undefined;
+/** 都道府県APIを呼び出す */
+function getPrefectures(): Promise<Prefectures> {
+  if (prefecturesCache) {
+    return prefecturesCache;
+  }
+
+  return prefecturesCache = (async () => {
+    const res = await fetch(PREFECTURES_URL, {
+      headers: { "X-API-KEY": RESAS_API_KEY },
+    });
+
+    // エラー時はキャッシュしない
+    if (!res.ok) {
+      console.error("failed to fetch API", res);
+      throw new Error("failed to fetch API");
+    }
+
+    return (await res.json()).result;
+  })();
+}
+// 初回実行時に強制的にAPIを呼び出し、キャッシュする
+getPrefectures().catch(console.error);

--- a/server/api_test.ts
+++ b/server/api_test.ts
@@ -1,12 +1,40 @@
 import {
   assert,
   assertEquals,
+  assertRejects,
 } from "https://deno.land/std@0.152.0/testing/asserts.ts";
-import { stub } from "https://deno.land/std@0.152.0/testing/mock.ts";
+import {
+  assertSpyCalls,
+  stub,
+} from "https://deno.land/std@0.152.0/testing/mock.ts";
 
-Deno.test({
-  name: "prefecturesApi",
-  async fn() {
+import { populationApi, prefecturesApi } from "./api.ts";
+
+Deno.test(async function prefecturesApiTest(t) {
+  await t.step("pattern", () => {
+    assert(prefecturesApi.pattern.test("http://foo.com/api/prefectures"));
+  });
+
+  await t.step("response error", async () => {
+    const fetchSpy = stub(
+      globalThis,
+      "fetch",
+      () => Promise.resolve(Response.error()),
+    );
+
+    try {
+      await assertRejects(async () => {
+        await prefecturesApi.route();
+      }, "failed to fetch API");
+
+      assertSpyCalls(fetchSpy, 1);
+    } finally {
+      fetchSpy.restore();
+    }
+  });
+
+  // エラーのレスポンスがキャッシュされていないことを確認します。
+  await t.step("response ok", async () => {
     const fetchMockValue = "__TEST_FETCH_MOCK__";
     const fetchSpy = stub(
       globalThis,
@@ -14,21 +42,47 @@ Deno.test({
       () => Promise.resolve(Response.json({ result: fetchMockValue })),
     );
     try {
-      const { prefecturesApi } = await import("./api.ts");
-      assert(prefecturesApi.pattern.test("http://foo.com/api/prefectures"));
-      const res = await prefecturesApi.route();
-      assertEquals(await res!.json(), fetchMockValue);
+      const res1 = await prefecturesApi.route();
+      const res2 = await prefecturesApi.route();
+      assertEquals(await res1!.json(), fetchMockValue);
+      assertEquals(await res2!.json(), fetchMockValue);
+
+      // routeを複数回呼び出しても、結果がキャッシュされているのでfetchの呼び出し回数は1回
+      assertSpyCalls(fetchSpy, 1);
     } finally {
       fetchSpy.restore();
     }
-  },
-  sanitizeResources: false,
-  sanitizeOps: false,
+  });
 });
 
-Deno.test({
-  name: "populationApi",
-  async fn() {
+Deno.test(async function populationApiTest(t) {
+  await t.step("pattern", () => {
+    assertEquals(
+      populationApi.pattern
+        .exec("http://foo.com/api/population/11")!.pathname.groups.prefCode,
+      "11",
+    );
+  });
+
+  await t.step("response error", async () => {
+    const fetchSpy = stub(
+      globalThis,
+      "fetch",
+      () => Promise.resolve(Response.error()),
+    );
+    try {
+      await assertRejects(async () => {
+        await populationApi.route(new URL("https://foo.com/"), {
+          // @ts-ignore: for test
+          pathname: { groups: { prefCode: "1" } },
+        });
+      });
+    } finally {
+      fetchSpy.restore();
+    }
+  });
+
+  await t.step("response error", async () => {
     const fetchMockValue = "__TEST_FETCH_MOCK__";
     const fetchSpy = stub(
       globalThis,
@@ -41,20 +95,20 @@ Deno.test({
         ),
     );
     try {
-      const { populationApi } = await import("./api.ts");
-
-      assertEquals(
-        populationApi.pattern
-          .exec("http://foo.com/api/population/11")!.pathname.groups.prefCode,
-        "11",
-      );
-      const res = await populationApi.route(new URL("https://foo.com/"), {
+      const res1 = await populationApi.route(new URL("https://foo.com/"), {
         // @ts-ignore: for test
         pathname: { groups: { prefCode: "1" } },
       });
-      assertEquals(await res!.json(), fetchMockValue);
+      const res2 = await populationApi.route(new URL("https://foo.com/"), {
+        // @ts-ignore: for test
+        pathname: { groups: { prefCode: "1" } },
+      });
+      assertEquals(await res1!.json(), fetchMockValue);
+      assertEquals(await res2!.json(), fetchMockValue);
+      // routeを複数回呼び出しても、結果がキャッシュされているのでfetchの呼び出し回数は1回
+      assertSpyCalls(fetchSpy, 1);
     } finally {
       fetchSpy.restore();
     }
-  },
+  });
 });


### PR DESCRIPTION
サーバー側のキャッシュでは、API呼び出しでエラーが発生した際に、そのエラーが永遠にキャッシュされてしまうという問題がありました。

エラーが発生した場合はキャッシュせずに、次回のリクエストでもう一度APIを呼び出す必要があります。